### PR TITLE
omx: Skip the whole dataspace signaling on legacy QCOM

### DIFF
--- a/media/libstagefright/omx/GraphicBufferSource.cpp
+++ b/media/libstagefright/omx/GraphicBufferSource.cpp
@@ -576,7 +576,6 @@ void GraphicBufferSource::onDataSpaceChanged_l(
                 aspects.mTransfer, asString(aspects.mTransfer),
                 err, asString(err));
 
-#ifndef QCOM_BSP_LEGACY
         // signal client that the dataspace has changed; this will update the output format
         // TODO: we should tie this to an output buffer somehow, and signal the change
         // just before the output buffer is returned to the client, but there are many
@@ -586,7 +585,6 @@ void GraphicBufferSource::onDataSpaceChanged_l(
                 OMX_EventDataSpaceChanged, dataSpace,
                 (aspects.mRange << 24) | (aspects.mPrimaries << 16)
                         | (aspects.mMatrixCoeffs << 8) | aspects.mTransfer);
-#endif
     }
 }
 
@@ -634,11 +632,12 @@ bool GraphicBufferSource::fillCodecBuffer_l() {
         mBufferUseCount[item.mSlot] = 0;
     }
 
+#ifndef QCOM_BSP_LEGACY
     if (item.mDataSpace != mLastDataSpace) {
         onDataSpaceChanged_l(
                 item.mDataSpace, (android_pixel_format)mBufferSlot[item.mSlot]->getPixelFormat());
     }
-
+#endif
 
     err = UNKNOWN_ERROR;
 


### PR DESCRIPTION
Instead of going through the whole setup process,
and then skip the signaling for legacy QCOM at the end,
just skip the whole process.

Change-Id: I2c3e114be9c5ae0462c6c4e758c0c757465c3eb3