### PR TITLE
audioflinger: Use offloaded effects in case of PCM offload

### DIFF
--- a/services/audioflinger/Effects.cpp
+++ b/services/audioflinger/Effects.cpp
@@ -93,6 +93,7 @@ AudioFlinger::EffectModule::EffectModule(ThreadBase *thread,
 {
     ALOGV("Constructor %p pinned %d", this, pinned);
     int lStatus;
+    bool setVal = false;
 
     // create effect engine from effect factory
     mStatus = EffectCreate(&desc->uuid, sessionId, thread->id(), &mEffectInterface);
@@ -105,8 +106,11 @@ AudioFlinger::EffectModule::EffectModule(ThreadBase *thread,
         mStatus = lStatus;
         goto Error;
     }
-
-    setOffloaded(thread->type() == ThreadBase::OFFLOAD, thread->id());
+    if (thread->type() == ThreadBase::OFFLOAD ||
+        (thread->type() == ThreadBase::DIRECT && thread->mIsDirectPcm)) {
+        setVal = true;
+    }
+    setOffloaded(setVal, thread->id());
 
     ALOGV("Constructor success name %s, Interface %p", mDescriptor.name, mEffectInterface);
     return;

--- a/services/audioflinger/Threads.cpp
+++ b/services/audioflinger/Threads.cpp
@@ -1523,12 +1523,6 @@ sp<AudioFlinger::EffectHandle> AudioFlinger::ThreadBase::createEffect_l(
             effectRegistered = true;
             // create a new effect module if none present in the chain
             lStatus = chain->createEffect_l(effect, this, desc, id, sessionId, pinned);
-
-            bool setVal = false;
-            if (mType == OFFLOAD || (mType == DIRECT && mIsDirectPcm)) {
-                setVal = true;
-            }
-
             if (lStatus != NO_ERROR) {
                 goto Exit;
             }


### PR DESCRIPTION
These lines are not available in AOSP, so when d5ee6cee33f0e7580612
("DO NOT MERGE - improve audio effect framwework thread safety") was
applied, they were left behind and currently don't make any difference.

Change-Id: I73c3eaa2f3a67fe8cbbb9b59473c85c838ecbf77