### PR TITLE
Revert "libstagefright: Use proper ctts offset"

### DIFF
--- a/media/libstagefright/ACodec.cpp
+++ b/media/libstagefright/ACodec.cpp
@@ -3907,7 +3907,6 @@ status_t ACodec::setupVideoEncoder(
         if (!msg->findInt32("frame-rate", &tmp)) {
             return INVALID_OPERATION;
         }
-        outputFormat->setInt32("frame-rate", tmp);
         frameRate = (float)tmp;
         mTimePerFrameUs = (int64_t) (1000000.0f / frameRate);
     }


### PR DESCRIPTION
* This commit appears to break camcorder for sailfish and probably
  marlin too.

This reverts commit 9d63d49e8f23fd93afb0f1e18fa306f1e22e2870.

Change-Id: Id1eb983781a308c96c3b43943f273062c680872f