### PR TITLE
Visualizer: fix native crash when visualizer release

### DIFF
--- a/media/libmedia/include/media/Visualizer.h
+++ b/media/libmedia/include/media/Visualizer.h
@@ -131,6 +131,7 @@ public:
     // getCaptureSize() but the length of the FFT is half of the size (both parts of the spectrum
     // are returned
     status_t getFft(uint8_t *fft);
+    void release();
 
 protected:
     // from IEffectClient
@@ -146,12 +147,12 @@ private:
     class CaptureThread : public Thread
     {
     public:
-        CaptureThread(Visualizer& receiver, uint32_t captureRate, bool bCanCallJava = false);
+        CaptureThread(Visualizer* visualizer, uint32_t captureRate, bool bCanCallJava = false);
 
     private:
         friend class Visualizer;
         virtual bool        threadLoop();
-        Visualizer& mReceiver;
+        wp<Visualizer> mReceiver;
         Mutex       mLock;
         uint32_t mSleepTimeUs;
     };


### PR DESCRIPTION
When the Visualizer effect is released, synchronous wait for the CaptureThread can
cause ANR in an app. This is why an asynchronous 'release' method is introduced which
is used by Visualizer.release() method on the Java side. Since CaptureThread may still
be running while the the last reference to the Visualizer instance is released,
CaptureThread now holds a strong reference to the Visualizer, which it releases
upon exit from the thread loop.

The 'release' method does not check for 'enabled' status because setEnabled(false)
may fail due to audioserver calling AudioFlinger::EffectHandle::setControl to
hold control.

Test: CTS VisualizerTest
Change-Id: I8d936f0f79540345d3e3675f6129bb942a08e423
Signed-off-by: zengjing <zengjing@xiaomi.com>